### PR TITLE
Issue 10: switch print statement to logging.debug statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turnpy"
-version = "1.1.0"
+version = "1.2.1"
 description = "A package to help you connect to the Turn.io API from a Python app"
 authors = [
     "Rising Academies",

--- a/turnpy/turn_integrator.py
+++ b/turnpy/turn_integrator.py
@@ -1,35 +1,46 @@
-from requests.auth import HTTPBasicAuth
-from datetime import datetime
-import requests
 import json
+import logging
+from datetime import datetime
+
+import requests
+from requests.auth import HTTPBasicAuth
+
 
 """SETUP"""
 """
 Load and evaluate the cedentials from the turn_config.json file.
 """
+logger = logging.getLogger(__name__)
+
+
 def load_credentials(file_name: str, line_name: str) -> str:
-    with open(file_name, 'r') as file:
+    with open(file_name, "r") as file:
         turn_config = json.load(file)
 
-    return turn_config['lines'][line_name]
+    return turn_config["lines"][line_name]
+
 
 """
 Determine if the Turn credentials are still valid.
 """
+
+
 def eval_credentials(config_json: json) -> str:
-    with open('turn_config.json', 'r') as file:
+    with open("turn_config.json", "r") as file:
         turn_config = json.load(file)
 
-    token_expiry = datetime.strptime(config_json["expiry"], '%b %d, %Y %I:%M %p')
+    token_expiry = datetime.strptime(config_json["expiry"], "%b %d, %Y %I:%M %p")
     if token_expiry > datetime.now():
         return config_json["token"]
     else:
         raise ValueError("API key has expired for this Turn line.")
 
+
 def turn_credentials(line_name):
-    config_json = load_credentials('turn_config.json', line_name)
+    config_json = load_credentials("turn_config.json", line_name)
 
     return eval_credentials(config_json)
+
 
 """CONTACTS"""
 """
@@ -38,30 +49,44 @@ Obtain a contact profile.
 See documentation here:
 https://whatsapp.turn.io/docs/api/contacts#retrieve-a-contact-profile
 """
+
+
 def obtain_contact_profile(msisdn: str, line_name: str) -> requests.Response:
     auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}',
-        'Accept': 'application/vnd.v1+json'
+        "Authorization": f"Bearer {turn_credentials(line_name)}",
+        "Accept": "application/vnd.v1+json",
     }
 
-    response = requests.get(f'https://whatsapp.turn.io/v1/contacts/{msisdn}/profile', headers=auth_headers)
-    print(response.text)
+    response = requests.get(
+        f"https://whatsapp.turn.io/v1/contacts/{msisdn}/profile", headers=auth_headers
+    )
+    logging.debug("Obtained contact profile response", response.text)
     return response
+
 
 """Update a contact profile.
 
 Supply only the fields that need updating. See documentation here:
 https://whatsapp.turn.io/docs/api/contacts#update-a-contact-profile
 """
-def update_contact_profile(msisdn: str, line_name: str, profile_data: json) -> requests.Response:
+
+
+def update_contact_profile(
+    msisdn: str, line_name: str, profile_data: json
+) -> requests.Response:
     auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}',
-        'Accept': 'application/vnd.v1+json'
+        "Authorization": f"Bearer {turn_credentials(line_name)}",
+        "Accept": "application/vnd.v1+json",
     }
 
-    response = requests.patch(f'https://whatsapp.turn.io/v1/contacts/{msisdn}/profile', headers=auth_headers, json=profile_data)
-    print(response.text)
+    response = requests.patch(
+        f"https://whatsapp.turn.io/v1/contacts/{msisdn}/profile",
+        headers=auth_headers,
+        json=profile_data,
+    )
+    logging.debug("Updated contact profile response", response.text)
     return response
+
 
 """ MESSAGES"""
 """
@@ -69,12 +94,15 @@ Send the different kinds of messages.
 
 See documentation here: https://whatsapp.turn.io/docs/api/messages
 """
-def send_message(line_name: str, message_data: json) -> requests.Response:
-    auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}'
-    }
 
-    return requests.post('https://whatsapp.turn.io/v1/messages', headers=auth_headers, json=message_data)
+
+def send_message(line_name: str, message_data: json) -> requests.Response:
+    auth_headers = {"Authorization": f"Bearer {turn_credentials(line_name)}"}
+
+    return requests.post(
+        "https://whatsapp.turn.io/v1/messages", headers=auth_headers, json=message_data
+    )
+
 
 """
 Send a text message.
@@ -82,22 +110,25 @@ Send a text message.
 The recipient_type is currrently hardcoded to "individual" as there are no API docs pointing to
 another type of recipient.
 """
+
+
 def send_text_message(msisdn: str, line_name: str, message: str) -> requests.Response:
     message_data = {
-        'preview_url': False,
-        'recipient_type': 'individual',
-        'to': f'{msisdn}',
-        'type': 'text',
-        'text': {
-            'body': message
-        }
+        "preview_url": False,
+        "recipient_type": "individual",
+        "to": f"{msisdn}",
+        "type": "text",
+        "text": {"body": message},
     }
 
     response = send_message(line_name, message_data)
-    print(response.text)
+    logging.debug("Sent text message response", response.text)
     return response
 
-def send_media_message(msisdn: str, line_name: str, media_type: str, media_id: str, caption="") -> requests.Response:
+
+def send_media_message(
+    msisdn: str, line_name: str, media_type: str, media_id: str, caption=""
+) -> requests.Response:
     message_data = {
         "to": msisdn,
         "recipient_type": "individual",
@@ -108,17 +139,11 @@ def send_media_message(msisdn: str, line_name: str, media_type: str, media_id: s
 
     elif media_type == "document":
         message_data["type"] = "document"
-        message_data["document"] = {
-            "id": media_id,
-            "caption": caption
-        }
+        message_data["document"] = {"id": media_id, "caption": caption}
 
     elif media_type == "image":
         message_data["type"] = "image"
-        message_data["image"] = {
-            "id": media_id,
-            "caption": caption
-        }
+        message_data["image"] = {"id": media_id, "caption": caption}
 
     elif media_type == "sticker":
         message_data["type"] = "sticket"
@@ -126,13 +151,10 @@ def send_media_message(msisdn: str, line_name: str, media_type: str, media_id: s
 
     elif media_type == "video":
         message_data["type"] = "video"
-        message_data["video"] = {
-            "id": media_id,
-            "caption": caption
-        }
+        message_data["video"] = {"id": media_id, "caption": caption}
 
     response = send_message(line_name, message_data)
-    print(response.text)
+    logging.debug("Sent media message response", response.text)
     return response
 
 
@@ -151,68 +173,61 @@ Further details about the API call here:
 https://whatsapp.turn.io/docs/api/messages#interactive-messages
 """
 
-def send_interactive_message(msisdn: str, line_name: str, interactive_type: str, sections: json) -> requests.Response:
+
+def send_interactive_message(
+    msisdn: str, line_name: str, interactive_type: str, sections: json
+) -> requests.Response:
     message_data = {
         "to": msisdn,
         "type": "interactive",
         "interactive": {
             "type": interactive_type,
-            "body": {
-                "text": sections['body_text']
-            },
-            'action': {}
+            "body": {"text": sections["body_text"]},
+            "action": {},
         },
     }
 
-    if sections['header_text']:
-        message_data['interactive']['header'] = {
+    if sections["header_text"]:
+        message_data["interactive"]["header"] = {
             "type": "text",
-            "text": sections['header_text']
+            "text": sections["header_text"],
         }
-    elif sections['header_image']:
-        message_data['interactive']['header'] = {
+    elif sections["header_image"]:
+        message_data["interactive"]["header"] = {
             "type": "image",
-            "id": sections['header_image']
+            "id": sections["header_image"],
         }
 
-    if sections['footer_text']:
-        message_data['interactive']['footer'] = {
-            "text": sections['footer_text']
-        }
+    if sections["footer_text"]:
+        message_data["interactive"]["footer"] = {"text": sections["footer_text"]}
 
-    if interactive_type == 'button':
-        message_data['interactive']['action']['buttons'] = []
-        for button in sections['buttons']:
-            message_data['interactive']['action']['buttons'].append(
+    if interactive_type == "button":
+        message_data["interactive"]["action"]["buttons"] = []
+        for button in sections["buttons"]:
+            message_data["interactive"]["action"]["buttons"].append(
                 {
                     "type": "reply",
-                    "reply": {
-                        "id": button['callback_id'],
-                        "title": button['text']
-                    }
+                    "reply": {"id": button["callback_id"], "title": button["text"]},
                 }
             )
 
-    if interactive_type == 'list':
-        message_data['interactive']['action']['button'] = sections['list_button']
-        message_data['interactive']['action']['sections'] = []
-        message_data['interactive']['action']['sections'].append({})
-        message_data['interactive']['action']['sections'][0]['title'] = sections['list_title']
-        message_data['interactive']['action']['sections'][0]['rows'] = []
-        for list_item in sections['list_items']:
-            message_data['interactive']['action']['sections'][0]['rows'].append(
-                {
-                    "id": list_item['callback_id'],
-                    "title": list_item['text']
-                }
+    if interactive_type == "list":
+        message_data["interactive"]["action"]["button"] = sections["list_button"]
+        message_data["interactive"]["action"]["sections"] = []
+        message_data["interactive"]["action"]["sections"].append({})
+        message_data["interactive"]["action"]["sections"][0]["title"] = sections[
+            "list_title"
+        ]
+        message_data["interactive"]["action"]["sections"][0]["rows"] = []
+        for list_item in sections["list_items"]:
+            message_data["interactive"]["action"]["sections"][0]["rows"].append(
+                {"id": list_item["callback_id"], "title": list_item["text"]}
             )
 
-
-
-    print(message_data)
     response = send_message(line_name, message_data)
-    print(response.text)
+    logging.debug("Sent interactive message response", response.text)
     return response
+
 
 """MEDIA"""
 """
@@ -221,14 +236,19 @@ Save media to Turn for sending.
 See the supported file types on the Turn documentation here:
 https://whatsapp.turn.io/docs/api/media#supported-file-types
 """
+
+
 def save_media(line_name: str, type: str, file_binary: str) -> requests.Response:
     auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}',
-        'Content-Type': type
+        "Authorization": f"Bearer {turn_credentials(line_name)}",
+        "Content-Type": type,
     }
-    response = requests.post('https://whatsapp.turn.io/v1/media', headers=auth_headers, data=file_binary)
-    print(response.text)
+    response = requests.post(
+        "https://whatsapp.turn.io/v1/media", headers=auth_headers, data=file_binary
+    )
+    logging.debug("Saved media response", response.text)
     return response
+
 
 """CLAIMS"""
 """
@@ -237,25 +257,35 @@ or deleting one.
 
 See: https://whatsapp.turn.io/docs/api/extensions#managing-conversation-claims
 """
+
+
 def determine_claim(msisdn: str, line_name: str) -> requests.Response:
     auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}',
-        'Accept': 'application/vnd.v1+json'
+        "Authorization": f"Bearer {turn_credentials(line_name)}",
+        "Accept": "application/vnd.v1+json",
     }
-    response = requests.get(f'https://whatsapp.turn.io/v1/contacts/{msisdn}/claim', headers=auth_headers)
-    print(response.text)
+    response = requests.get(
+        f"https://whatsapp.turn.io/v1/contacts/{msisdn}/claim", headers=auth_headers
+    )
+    logging.debug("Determined claim response", response.text)
     return response
+
 
 def release_claim(msisdn: str, line_name: str, claim_uuid: str) -> requests.Response:
-    claim_data = { "claim_uuid": claim_uuid }
+    claim_data = {"claim_uuid": claim_uuid}
 
     auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}',
-        'Accept': 'application/vnd.v1+json'
+        "Authorization": f"Bearer {turn_credentials(line_name)}",
+        "Accept": "application/vnd.v1+json",
     }
-    response = requests.delete(f'https://whatsapp.turn.io/v1/contacts/{msisdn}/claim', headers=auth_headers, json=claim_data)
-    print(response.text)
+    response = requests.delete(
+        f"https://whatsapp.turn.io/v1/contacts/{msisdn}/claim",
+        headers=auth_headers,
+        json=claim_data,
+    )
+    logging.debug("Released claim response", response.text)
     return response
+
 
 """JOURNEYS"""
 """
@@ -264,13 +294,18 @@ Start a journey for a specific user.
 Details here: https://whatsapp.turn.io/docs/api/stacks
 """
 
+
 def start_journey(msisdn: str, line_name: str, stack_uuid: str) -> requests.Response:
-    journey_data = { "wa_id": msisdn }
+    journey_data = {"wa_id": msisdn}
 
     auth_headers = {
-        'Authorization': f'Bearer {turn_credentials(line_name)}',
-        'Accept': 'application/vnd.v1+json'
+        "Authorization": f"Bearer {turn_credentials(line_name)}",
+        "Accept": "application/vnd.v1+json",
     }
-    response = requests.post(f'https://whatsapp.turn.io/v1/stacks/{stack_uuid}/start', headers=auth_headers, json=journey_data)
-    print(response.text)
+    response = requests.post(
+        f"https://whatsapp.turn.io/v1/stacks/{stack_uuid}/start",
+        headers=auth_headers,
+        json=journey_data,
+    )
+    logging.debug("Started journey response", response.text)
     return response

--- a/turnpy/turn_integrator.py
+++ b/turnpy/turn_integrator.py
@@ -23,8 +23,6 @@ def load_credentials(file_name: str, line_name: str) -> str:
 """
 Determine if the Turn credentials are still valid.
 """
-
-
 def eval_credentials(config_json: json) -> str:
     with open("turn_config.json", "r") as file:
         turn_config = json.load(file)
@@ -49,8 +47,6 @@ Obtain a contact profile.
 See documentation here:
 https://whatsapp.turn.io/docs/api/contacts#retrieve-a-contact-profile
 """
-
-
 def obtain_contact_profile(msisdn: str, line_name: str) -> requests.Response:
     auth_headers = {
         "Authorization": f"Bearer {turn_credentials(line_name)}",
@@ -69,8 +65,6 @@ def obtain_contact_profile(msisdn: str, line_name: str) -> requests.Response:
 Supply only the fields that need updating. See documentation here:
 https://whatsapp.turn.io/docs/api/contacts#update-a-contact-profile
 """
-
-
 def update_contact_profile(
     msisdn: str, line_name: str, profile_data: json
 ) -> requests.Response:
@@ -94,8 +88,6 @@ Send the different kinds of messages.
 
 See documentation here: https://whatsapp.turn.io/docs/api/messages
 """
-
-
 def send_message(line_name: str, message_data: json) -> requests.Response:
     auth_headers = {"Authorization": f"Bearer {turn_credentials(line_name)}"}
 
@@ -110,8 +102,6 @@ Send a text message.
 The recipient_type is currrently hardcoded to "individual" as there are no API docs pointing to
 another type of recipient.
 """
-
-
 def send_text_message(msisdn: str, line_name: str, message: str) -> requests.Response:
     message_data = {
         "preview_url": False,
@@ -172,8 +162,6 @@ The sections argument is a dictionary with a few attrbutes:
 Further details about the API call here:
 https://whatsapp.turn.io/docs/api/messages#interactive-messages
 """
-
-
 def send_interactive_message(
     msisdn: str, line_name: str, interactive_type: str, sections: json
 ) -> requests.Response:
@@ -236,8 +224,6 @@ Save media to Turn for sending.
 See the supported file types on the Turn documentation here:
 https://whatsapp.turn.io/docs/api/media#supported-file-types
 """
-
-
 def save_media(line_name: str, type: str, file_binary: str) -> requests.Response:
     auth_headers = {
         "Authorization": f"Bearer {turn_credentials(line_name)}",
@@ -257,8 +243,6 @@ or deleting one.
 
 See: https://whatsapp.turn.io/docs/api/extensions#managing-conversation-claims
 """
-
-
 def determine_claim(msisdn: str, line_name: str) -> requests.Response:
     auth_headers = {
         "Authorization": f"Bearer {turn_credentials(line_name)}",
@@ -293,8 +277,6 @@ Start a journey for a specific user.
 
 Details here: https://whatsapp.turn.io/docs/api/stacks
 """
-
-
 def start_journey(msisdn: str, line_name: str, stack_uuid: str) -> requests.Response:
     journey_data = {"wa_id": msisdn}
 

--- a/turnpy/turn_integrator.py
+++ b/turnpy/turn_integrator.py
@@ -5,11 +5,11 @@ from datetime import datetime
 import requests
 from requests.auth import HTTPBasicAuth
 
-
 """SETUP"""
 """
 Load and evaluate the cedentials from the turn_config.json file.
 """
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,10 +19,10 @@ def load_credentials(file_name: str, line_name: str) -> str:
 
     return turn_config["lines"][line_name]
 
-
 """
 Determine if the Turn credentials are still valid.
 """
+
 def eval_credentials(config_json: json) -> str:
     with open("turn_config.json", "r") as file:
         turn_config = json.load(file)
@@ -39,7 +39,6 @@ def turn_credentials(line_name):
 
     return eval_credentials(config_json)
 
-
 """CONTACTS"""
 """
 Obtain a contact profile.
@@ -47,6 +46,7 @@ Obtain a contact profile.
 See documentation here:
 https://whatsapp.turn.io/docs/api/contacts#retrieve-a-contact-profile
 """
+
 def obtain_contact_profile(msisdn: str, line_name: str) -> requests.Response:
     auth_headers = {
         "Authorization": f"Bearer {turn_credentials(line_name)}",
@@ -59,12 +59,12 @@ def obtain_contact_profile(msisdn: str, line_name: str) -> requests.Response:
     logging.debug("Obtained contact profile response", response.text)
     return response
 
-
 """Update a contact profile.
 
 Supply only the fields that need updating. See documentation here:
 https://whatsapp.turn.io/docs/api/contacts#update-a-contact-profile
 """
+
 def update_contact_profile(
     msisdn: str, line_name: str, profile_data: json
 ) -> requests.Response:
@@ -81,13 +81,13 @@ def update_contact_profile(
     logging.debug("Updated contact profile response", response.text)
     return response
 
-
 """ MESSAGES"""
 """
 Send the different kinds of messages.
 
 See documentation here: https://whatsapp.turn.io/docs/api/messages
 """
+
 def send_message(line_name: str, message_data: json) -> requests.Response:
     auth_headers = {"Authorization": f"Bearer {turn_credentials(line_name)}"}
 
@@ -95,13 +95,13 @@ def send_message(line_name: str, message_data: json) -> requests.Response:
         "https://whatsapp.turn.io/v1/messages", headers=auth_headers, json=message_data
     )
 
-
 """
 Send a text message.
 
 The recipient_type is currrently hardcoded to "individual" as there are no API docs pointing to
 another type of recipient.
 """
+
 def send_text_message(msisdn: str, line_name: str, message: str) -> requests.Response:
     message_data = {
         "preview_url": False,
@@ -147,7 +147,6 @@ def send_media_message(
     logging.debug("Sent media message response", response.text)
     return response
 
-
 """Send an interactive message with a dropdown or buttons.
 
 The sections argument is a dictionary with a few attrbutes:
@@ -162,6 +161,7 @@ The sections argument is a dictionary with a few attrbutes:
 Further details about the API call here:
 https://whatsapp.turn.io/docs/api/messages#interactive-messages
 """
+
 def send_interactive_message(
     msisdn: str, line_name: str, interactive_type: str, sections: json
 ) -> requests.Response:
@@ -216,7 +216,6 @@ def send_interactive_message(
     logging.debug("Sent interactive message response", response.text)
     return response
 
-
 """MEDIA"""
 """
 Save media to Turn for sending.
@@ -224,6 +223,7 @@ Save media to Turn for sending.
 See the supported file types on the Turn documentation here:
 https://whatsapp.turn.io/docs/api/media#supported-file-types
 """
+
 def save_media(line_name: str, type: str, file_binary: str) -> requests.Response:
     auth_headers = {
         "Authorization": f"Bearer {turn_credentials(line_name)}",
@@ -235,7 +235,6 @@ def save_media(line_name: str, type: str, file_binary: str) -> requests.Response
     logging.debug("Saved media response", response.text)
     return response
 
-
 """CLAIMS"""
 """
 Manage claimed numbers, like determining a claim by a Turn process line a Journey,
@@ -243,6 +242,7 @@ or deleting one.
 
 See: https://whatsapp.turn.io/docs/api/extensions#managing-conversation-claims
 """
+
 def determine_claim(msisdn: str, line_name: str) -> requests.Response:
     auth_headers = {
         "Authorization": f"Bearer {turn_credentials(line_name)}",
@@ -270,13 +270,13 @@ def release_claim(msisdn: str, line_name: str, claim_uuid: str) -> requests.Resp
     logging.debug("Released claim response", response.text)
     return response
 
-
 """JOURNEYS"""
 """
 Start a journey for a specific user.
 
 Details here: https://whatsapp.turn.io/docs/api/stacks
 """
+
 def start_journey(msisdn: str, line_name: str, stack_uuid: str) -> requests.Response:
     journey_data = {"wa_id": msisdn}
 


### PR DESCRIPTION
This PR resolves #10 .  It switches `print` statements to `logging.debug` statements to afford more control over when the statements are output to logs.

Changes
* [x] Switch `print` statements to `logging.debug` statements
* [x] Style: Black formatting was applied to the turn_integrator.py file.
* [x] Bump turnpy version