### PR TITLE
Issue #12: send templated Messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turnpy"
-version = "1.1.0"
+version = "1.2.2"
 description = "A package to help you connect to the Turn.io API from a Python app"
 authors = [
     "Rising Academies",

--- a/test/test_turn_integrator.py
+++ b/test/test_turn_integrator.py
@@ -11,6 +11,7 @@ def load_test_config():
         "test_line": turn_config["test_line"],
         "test_number": turn_config["test_number"],
         "test_journey": turn_config["test_journey"],
+        "test_template": turn_config["test_template"],
     }
 
 
@@ -208,3 +209,22 @@ def test_start_journey():
 
     assert response.status_code == 201
     assert response_text["success"]
+
+
+@pytest.mark.vcr()
+def test_send_template_message():
+    test_config = load_test_config()
+    release_any_claim(test_config)
+
+    response = turn_integrator.send_template_message(
+        test_config["test_number"],
+        test_config["test_line"],
+        test_config["test_template"],
+        header_params=["Test Header"],
+        body_params=["Test Body Param 1"],
+        language="en"
+    )
+    response_text = json.loads(response.text)
+
+    assert response.status_code == 200
+    assert response_text["messages"][0]["id"]

--- a/test/test_turn_integrator.py
+++ b/test/test_turn_integrator.py
@@ -1,6 +1,8 @@
-import turnpy.turn_integrator as turn_integrator
-import pytest
 import json
+
+import pytest
+
+import turnpy.turn_integrator as turn_integrator
 
 
 def load_test_config():
@@ -222,7 +224,7 @@ def test_send_template_message():
         test_config["test_template"],
         header_params=["Test Header"],
         body_params=["Test Body Param 1"],
-        language="en"
+        language="en",
     )
     response_text = json.loads(response.text)
 

--- a/turn_config.json.example
+++ b/turn_config.json.example
@@ -2,10 +2,12 @@
   "lines": {
       "turn_line_1": {
         "token": "token_on_turn_for_line_1",
+        "template_namespace": "namespace_of_templates_for_line_1",
         "expiry": "expiry_date_in_format Apr 2, 2025 1:16 PM"
       },
       "turn_line_2": {
         "token": "token_on_turn_for_line_2",
+        "template_namespace": "namespace_of_templates_for_line_2",
         "expiry": "expiry_date_in_format May 2, 2025 1:16 PM"
       }
     },

--- a/turnpy/turn_integrator.py
+++ b/turnpy/turn_integrator.py
@@ -230,6 +230,63 @@ def save_media(line_name: str, type: str, file_binary: str) -> requests.Response
     print(response.text)
     return response
 
+"""TEMPLATES"""
+
+"""
+Send a templated message to a WhatsApp user.
+
+The arguments are:
+'msisdn' - string, required WhatsApp ID to send to
+'line_name' - string, required Turn line to use
+'template_name' - string, required name of the template to use
+'header_params' - list, optional list of strings for header placeholders
+'body_params' - list, optional list of strings for body placeholders
+'language' - string, optional language code for the template (default: 'en')
+
+Further details about the API call here:
+https://whatsapp.turn.io/docs/api/messages#template-messages
+"""
+
+def send_template_message(msisdn: str, line_name: str, template_name: str, header_params: list = None, body_params: list = None, language: str = 'en') -> requests.Response:
+
+    # Get credentials and config
+    config_json = load_credentials('turn_config.json', line_name)
+    template_namespace = config_json['template_namespace']
+
+    # Build the message data
+    message_data = {
+        "to": msisdn,
+        "type": "template",
+        "template": {
+            "namespace": template_namespace,
+            "name": template_name,
+            "language": {
+                "code": language,
+                "policy": "deterministic"
+            },
+            "components": []
+        }
+    }
+
+    if header_params:
+        header_component = {
+            "type": "header",
+            "parameters": [{"type": "text", "text": param} for param in header_params]
+        }
+        message_data["template"]["components"].append(header_component)
+
+    if body_params:
+        body_component = {
+            "type": "body",
+            "parameters": [{"type": "text", "text": param} for param in body_params]
+        }
+        message_data["template"]["components"].append(body_component)
+
+    response = send_message(line_name, message_data)
+    print(response.text)
+    return response
+
+
 """CLAIMS"""
 """
 Manage claimed numbers, like determining a claim by a Turn process line a Journey,


### PR DESCRIPTION
This PR reserves #12 and adds the capability to send template messages as per [Turn.io documentation](https://whatsapp.turn.io/docs/api/messages#templated-messages)

* [x] Added `send_templated_message` method
* [x] Added test for the method
* [x] Styling: will apply black before merge.
* [x] Bump package version  