### PR TITLE
Add an optional text message argument to a media message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turnpy"
-version = "1.2.2"
+version = "1.3.0"
 description = "A package to help you connect to the Turn.io API from a Python app"
 authors = [
     "Rising Academies",

--- a/turnpy/turn_integrator.py
+++ b/turnpy/turn_integrator.py
@@ -115,7 +115,7 @@ def send_text_message(msisdn: str, line_name: str, message: str) -> requests.Res
     return response
 
 def send_media_message(
-    msisdn: str, line_name: str, media_type: str, media_id: str, caption=""
+    msisdn: str, line_name: str, media_type: str, media_id: str, caption="", message: str=""
 ) -> requests.Response:
     message_data = {
         "to": msisdn,
@@ -140,6 +140,9 @@ def send_media_message(
     elif media_type == "video":
         message_data["type"] = "video"
         message_data["video"] = {"id": media_id, "caption": caption}
+
+    if message:
+        message_data["text"] = {"body": message}
 
     response = send_message(line_name, message_data)
     logging.debug("Sent media message response", response.text)
@@ -311,6 +314,8 @@ def determine_claim(msisdn: str, line_name: str) -> requests.Response:
     )
     logging.debug("Determined claim response", response.text)
     return response
+
+
 
 def release_claim(msisdn: str, line_name: str, claim_uuid: str) -> requests.Response:
     claim_data = {"claim_uuid": claim_uuid}


### PR DESCRIPTION
This PR adds an optional text message to a media message.  This would allow a user to add context to the media message.  For example, one might add instructions for how to play an audio message with the audio message.